### PR TITLE
add pods

### DIFF
--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: vitalykorneev/kubernetes-intro-frontend:latest
+    name: frontend
+    resources: {}
+    env:
+    - name: PORT
+      value: "8080"
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "productcatalogservice:3550"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "currencyservice:7000"
+    - name: CART_SERVICE_ADDR
+      value: "cartservice:7070"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "recommendationservice:8080"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "shippingservice:50051"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "checkoutservice:5050"
+    - name: AD_SERVICE_ADDR
+      value: "adservice:9555"
+    - name: ENV_PLATFORM
+      value: "gcp"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: vitalykorneev/kubernetes-intro-frontend:latest
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+  - name: web
+    image: vitalykorneev/kubernetes-intro-web:latest
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  initContainers:
+  - name: init
+    image: busybox:1.31.0
+    command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  volumes:
+  - name: app
+    emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,16 @@
+FROM nginx:1.17.6-alpine
+
+RUN addgroup -g 1001 docker
+RUN adduser -u 1001 -G docker -s /bin/sh -D docker
+RUN chown docker /var/cache/nginx
+RUN chown docker /var/run
+
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
+
+USER docker
+
+WORKDIR /app
+
+EXPOSE 8000
+
+CMD nginx -g 'daemon off;'

--- a/kubernetes-intro/web/nginx/default.conf
+++ b/kubernetes-intro/web/nginx/default.conf
@@ -1,0 +1,5 @@
+server {
+    listen 8000;
+    access_log /dev/null;
+    root /app;
+}


### PR DESCRIPTION
# Выполнено ДЗ № 1

 - [+] Основное ДЗ
 - [+] Задание со *

## В процессе сделано:
 - Установлен kubectl и Minikube
 - Ознакомление с основными командами kubectl
 - Создан Dockerfile запускающий web-сервер на порту 8000 и создающий пользователя `docker`
 - Создан манифест web-pod.yaml и запущен соответсвующий под
 - Проверена работоспособность web сервера
 - Ознакомление с альтернативными методами создания манифестов и запуска подов
 - Создание манифеста сервиса hipster-frontend. Поиск ошибки и устранение путем добавления в манифест список env 

## Как запустить проект:
 - Запустить под `kubectl apply -f web-pod.yaml`
 - Есть возможность запустить под с отслеживанием процесса `kubectl apply -f web-pod.yaml && kubectl get pods -w`
 - Запустить под без создания манифеста `kubectl run frontend --image avtandilko/hipster-frontend:v0.0.1 --restart=Never`
 - Запустить под и сгенерить манифест `kubectl run frontend --image avtandilko/hipster-frontend:v0.0.1 --restart=Never --dry-run -o yaml > frontend-pod.yaml`

## Как проверить работоспособность:
 - Проверить под на наличие ошибок `kubectl describe pod web`
 - Выполнить команду `kubectl port-forward --address 0.0.0.0 pod/web 8000:8000` и  перейти по ссылке http://localhost:8000

## Почему все pod в namespace kube-system восстановились после удаления
 - Неймспейс kube-system используются для запуска служебных объектов Kubernetes, необходимых для корректной работы кластера.
 - kube-apiserver является static pod. Запускается через kubelet. [Описание поведения static pods](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/#behavior-of-static-pods)
 - сoredns под управляется через deployments контроллер который создает replicaset

## PR checklist:
 - [+] Выставлен label с темой домашнего задания